### PR TITLE
Lower java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>19</maven.compiler.source>
-        <maven.compiler.target>19</maven.compiler.target>
+        <maven.compiler.source>10</maven.compiler.source>
+        <maven.compiler.target>10</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>


### PR DESCRIPTION
A [quick google search](https://javabeginners.de/Grundlagen/Datentypen/var.php) gave that version 10 is required vor `var`. And it seems to compile with this version.